### PR TITLE
[BUGFIX] Use GPL-2.0 text as a needle for GPL-2.0

### DIFF
--- a/src/Enum/License.php
+++ b/src/Enum/License.php
@@ -28,7 +28,7 @@ enum License: string
     case GPL20 = '
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
-* the Free Software Foundation, either version 3 of the License, or
+* the Free Software Foundation, either version 2 of the License, or
 * (at your option) any later version.
 ';
     case GPL30 = '


### PR DESCRIPTION
Fixed a bug where the GPL v3 text was expected for GPL v2.